### PR TITLE
DOC: Use full state names; add RST formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,17 +14,18 @@ Available states
 .. contents::
     :local:
 
-``dist-upgrade``
-----------------
+``apt.dist-upgrade``
+--------------------
 
-Runs apt-get dist-upgrade.
+Runs ``apt-get dist-upgrade``.
 
-``update``
-----------
+``apt.update``
+--------------
 
-Runs apt-get update.
+Runs ``apt-get update``.
 
-``upgrade``
------------
+``apt.upgrade``
+---------------
 
-Runs apt-get upgrade.
+Runs ``apt-get upgrade``.
+


### PR DESCRIPTION
It's easier to match full state paths to top file paths. Example: https://github.com/saltstack-formulas/salt-formula#available-states
