### PR TITLE
Resolve map variable conflict

### DIFF
--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -1,4 +1,4 @@
-{% set map = salt['grains.filter_by']({
+{% set apt = salt['grains.filter_by']({
     'Debian': {
         'pkgs': ['unattended-upgrades'],
         'confd_dir': '/etc/apt/apt.conf.d',

--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -3,6 +3,6 @@
         'pkgs': ['unattended-upgrades'],
         'confd_dir': '/etc/apt/apt.conf.d',
         'unattended_config': '50unattended-upgrades',
-        'periodic_config': '02periodic',
+        'periodic_config': '10periodic',
     },
 }, merge=salt['pillar.get']('apt:lookup')) %}

--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -5,4 +5,4 @@
         'unattended_config': '50unattended-upgrades',
         'periodic_config': '02periodic',
     },
-}, grain='os', merge=salt['pillar.get']('apt:lookup')) %}
+}, merge=salt['pillar.get']('apt:lookup')) %}

--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -5,4 +5,4 @@
         'unattended_config': '50unattended-upgrades',
         'periodic_config': '10periodic',
     },
-}, merge=salt['pillar.get']('apt:lookup')) %}
+}, merge=salt['pillar.get']('apt:lookup'), default='Debian') %}

--- a/apt/templates/periodic_config.jinja
+++ b/apt/templates/periodic_config.jinja
@@ -1,0 +1,13 @@
+{% set apt = pillar.get('apt:unattended', {}) -%}
+{% set enabled = apt.get('enabled', '1') -%}
+{% set update_package_lists = apt.get('update_package_lists', '1') -%}
+{% set download_upgradeable_packages = apt.get('download_upgradeable_packages', '1') -%}
+{% set unattended_upgrade = apt.get('unattended_upgrade', '1') -%}
+{% set auto_clean_interval = apt.get('auto_clean_interval', '7') -%}
+{% set verbose = apt.get('verbose', '2') -%}
+APT::Periodic::Enable "{{ enabled }}"; 
+APT::Periodic::Update-Package-Lists "{{ update_package_lists }}";
+APT::Periodic::Download-Upgradeable-Packages "{{ download_upgradeable_packages }}";
+APT::Periodic::Unattended-Upgrade "{{ unattended_upgrade }}";
+APT::Periodic::AutocleanInterval "{{ auto_clean_interval }}";
+APT::Periodic::Verbose "{{ verbose }}";

--- a/apt/templates/unattended_config.jinja
+++ b/apt/templates/unattended_config.jinja
@@ -1,0 +1,31 @@
+{% set apt = pillar.get('apt:unattended', {}) -%}
+{% set allowed_origins = apt.get('allowed_origins', ['${distro_id}:${distro_codename}-security']) -%}
+{% set package_blacklist = apt.get('package_blacklist', {}) -%}
+{% set auto_fix_interrupted_dpkg = apt.get('auto_fix_interrupted_dpkg', 'true') -%}
+{% set minimal_steps = apt.get('minimal_steps', 'false') -%}
+{% set install_on_shutdown = apt.get('install_on_shutdown', 'false') -%}
+{% set mail = apt.get('mail', 'root') -%}
+{% set mail_only_on_error = apt.get('mail_only_on_error', 'false') -%}
+{% set remove_unused_dependencies = apt.get('remove_unused_dependencies', 'true') -%}
+{% set automatic_reboot = apt.get('automatic_reboot', 'false') -%}
+{% set automatic_reboot_time = apt.get('automatic_reboot_time', 'now') -%}
+{% set dl_limit = apt.get('dl_limit', '0') -%}
+Unattended-Upgrade::Allowed-Origins {
+        {%- for pattern in allowed_origins %}
+        "{{ pattern }}";
+        {%- endfor %} 
+};
+Unattended-Upgrade::Package-Blacklist {
+        {%- for package in package_blacklist %}
+        "{{ package }}";
+        {%- endfor %} 
+};
+Unattended-Upgrade::AutoFixInterruptedDpkg "{{ auto_fix_interrupted_dpkg }}";
+Unattended-Upgrade::MinimalSteps "{{ minimal_steps }}";
+Unattended-Upgrade::InstallOnShutdown "{{ install_on_shutdown }}";
+Unattended-Upgrade::Mail "{{ mail }}";
+Unattended-Upgrade::MailOnlyOnError "{{ mail_only_on_error }}";
+Unattended-Upgrade::Remove-Unused-Dependencies "{{ remove_unused_dependencies }}";
+Unattended-Upgrade::Automatic-Reboot "{{ automatic_reboot }}";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ automatic_reboot_time }}";
+Acquire::http::Dl-Limit "{{ dl_limit }}";

--- a/apt/unattended.sls
+++ b/apt/unattended.sls
@@ -11,7 +11,7 @@ apt_unattended_pakgs::
       - {{ pkg }}
       {% endfor %}  
 
-{{ apt.confd_dir }}/{{ apt.unattended_config }}:
+{{ apt_map.confd_dir }}/{{ apt_map.unattended_config }}:
   file.managed:
     - template: jinja
     - user: root
@@ -19,7 +19,7 @@ apt_unattended_pakgs::
     - mode: 644
     - source: {{ unattended_config_template }}
 
-{{ apt.confd_dir }}/{{ apt.periodic_config }}:
+{{ apt_map.confd_dir }}/{{ apt_map.periodic_config }}:
   file.managed:
     - template: jinja
     - user: root

--- a/apt/unattended.sls
+++ b/apt/unattended.sls
@@ -1,5 +1,5 @@
 # This is the main state file for configuring unattended upgrades with apt
-{% from "apt/map.jinja" import apt with context %}
+{% from "apt/map.jinja" import apt as apt_map with context %}
 {% set apt = pillar.get('apt:unattended', {}) -%}
 {% set unattended_config_template = apt.get('unattended_config_template', 'salt://apt/templates/unattended_config.jinja') -%}
 {% set periodic_config_template = apt.get('periodic_config_template', 'salt://apt/templates/periodic_config.jinja') -%}
@@ -7,7 +7,7 @@
 apt_unattended_pakgs::
   pkg.installed:
     - pkgs:
-      {% for pkg in apt.pkgs %}
+      {% for pkg in apt_map.pkgs %}
       - {{ pkg }}
       {% endfor %}  
 

--- a/apt/unattended.sls
+++ b/apt/unattended.sls
@@ -1,11 +1,11 @@
 # This is the main state file for configuring unattended upgrades with apt
 
-{% from "apt/map.jinja" import map with context %}
+{% from "apt/map.jinja" import apt with context %}
 
 apt_unattended_pakgs::
   pkg.installed:
     - pkgs:
-      {% for pkg in map.pkgs %}
+      {% for pkg in apt.pkgs %}
       - {{ pkg }}
       {% endfor %}  
 
@@ -20,7 +20,7 @@ apt_unattended_pakgs::
 {% set automatic_reboot = salt['pillar.get']('apt:unattended:automatic_reboot', 'false') %}
 {% set dl_limit = salt['pillar.get']('apt:unattended:dl_limit', '0') %}
 
-{{ map.confd_dir }}/{{ map.unattended_config }}:
+{{ apt.confd_dir }}/{{ apt.unattended_config }}:
   file.managed:
     - contents: |
         Unattended-Upgrade::Origins-Pattern {
@@ -49,7 +49,7 @@ apt_unattended_pakgs::
 {% set auto_clean_interval = salt['pillar.get']('apt:unattended:auto_clean_interval', '7') %}
 {% set verbose = salt['pillar.get']('apt:unattended:verbose', '2') %}
 
-{{ map.confd_dir }}/{{ map.periodic_config }}:
+{{ apt.confd_dir }}/{{ apt.periodic_config }}:
   file.managed:
     - contents: |
         APT::Periodic::Enable "{{ enabled }}"; 

--- a/apt/unattended.sls
+++ b/apt/unattended.sls
@@ -1,6 +1,8 @@
 # This is the main state file for configuring unattended upgrades with apt
-
 {% from "apt/map.jinja" import apt with context %}
+{% set apt = pillar.get('apt:unattended', {}) -%}
+{% set unattended_config_template = apt.get('unattended_config_template', 'salt://apt/templates/unattended_config.jinja') -%}
+{% set periodic_config_template = apt.get('periodic_config_template', 'salt://apt/templates/periodic_config.jinja') -%}
 
 apt_unattended_pakgs::
   pkg.installed:
@@ -9,52 +11,18 @@ apt_unattended_pakgs::
       - {{ pkg }}
       {% endfor %}  
 
-{% set origins_pattern = salt['pillar.get']('apt:unattended:origings_pattern', ['origin=Debian,archive=stable,label=Debian-Security']) %}
-{% set package_blacklist = salt['pillar.get']('apt:unattended:package_blacklist', {}) %}
-{% set auto_fix_interrupted_dpkg = salt['pillar.get']('apt:unattended:auto_fix_interrupted_dpkg', 'true') %}
-{% set minimal_steps = salt['pillar.get']('apt:unattended:minimal_steps', 'false') %}
-{% set install_on_shutdown = salt['pillar.get']('apt:unattended:install_on_shutdown', 'false') %}
-{% set mail = salt['pillar.get']('apt:unattended:mail', 'root') %}
-{% set mail_only_on_error = salt['pillar.get']('apt:unattended:mail_only_on_error', 'false') %}
-{% set remove_unused_dependencies = salt['pillar.get']('apt:unattended:remove_unused_dependencies', 'true') %}
-{% set automatic_reboot = salt['pillar.get']('apt:unattended:automatic_reboot', 'false') %}
-{% set dl_limit = salt['pillar.get']('apt:unattended:dl_limit', '0') %}
-
 {{ apt.confd_dir }}/{{ apt.unattended_config }}:
   file.managed:
-    - contents: |
-        Unattended-Upgrade::Origins-Pattern {
-          {%- for pattern in origins_pattern %}
-          "{{ pattern }}";
-          {%- endfor %} 
-        };
-        Unattended-Upgrade::Package-Blacklist {
-          {%- for package in package_blacklist %}
-          "{{ package }}";
-          {%- endfor %} 
-        };
-        Unattended-Upgrade::AutoFixInterruptedDpkg "{{ auto_fix_interrupted_dpkg }}";
-        Unattended-Upgrade::MinimalSteps "{{ minimal_steps }}";
-        Unattended-Upgrade::InstallOnShutdown "{{ install_on_shutdown }}";
-        Unattended-Upgrade::Mail "{{ mail }}";
-        Unattended-Upgrade::MailOnlyOnError "{{ mail_only_on_error }}";
-        Unattended-Upgrade::Remove-Unused-Dependencies "{{ remove_unused_dependencies }}";
-        Unattended-Upgrade::Automatic-Reboot "{{ automatic_reboot }}";
-        Acquire::http::Dl-Limit "{{ dl_limit }}";
-
-{% set enabled = salt['pillar.get']('apt:unattended:enabled', '1') %}
-{% set update_package_lists = salt['pillar.get']('apt:unattended:update_package_lists', '1') %}
-{% set download_upgradeable_packages = salt['pillar.get']('apt:unattended:download_upgradeable_packages', '1') %}
-{% set unattended_upgrade = salt['pillar.get']('apt:unattended:unattended_upgrade', '1') %}
-{% set auto_clean_interval = salt['pillar.get']('apt:unattended:auto_clean_interval', '7') %}
-{% set verbose = salt['pillar.get']('apt:unattended:verbose', '2') %}
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - source: {{ unattended_config_template }}
 
 {{ apt.confd_dir }}/{{ apt.periodic_config }}:
   file.managed:
-    - contents: |
-        APT::Periodic::Enable "{{ enabled }}"; 
-        APT::Periodic::Update-Package-Lists "{{ update_package_lists }}";
-        APT::Periodic::Download-Upgradeable-Packages "{{ download_upgradeable_packages }}";
-        APT::Periodic::Unattended-Upgrade "{{ unattended_upgrade }}";
-        APT::Periodic::AutocleanInterval "{{ auto_clean_interval }}";
-        APT::Periodic::Verbose "{{ verbose }}";
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - source: {{ periodic_config_template }}

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,6 @@
 apt:
   unattended:
-    origins_pattern:
+    allowed_origins:
       - origin1
       - origin2  
     package_blacklist:    


### PR DESCRIPTION
apt.unattended wasn't working for me, and I think it's because the variable name created in map.jinja is "map" which must have been used by a different formula already. Changing it to "apt" instead resolved the issue.