### PR TITLE
Fixed pillar.get calls

### DIFF
--- a/apt/templates/periodic_config.jinja
+++ b/apt/templates/periodic_config.jinja
@@ -1,10 +1,11 @@
-{% set apt = pillar.get('apt:unattended', {}) -%}
-{% set enabled = apt.get('enabled', '1') -%}
-{% set update_package_lists = apt.get('update_package_lists', '1') -%}
-{% set download_upgradeable_packages = apt.get('download_upgradeable_packages', '1') -%}
-{% set unattended_upgrade = apt.get('unattended_upgrade', '1') -%}
-{% set auto_clean_interval = apt.get('auto_clean_interval', '7') -%}
-{% set verbose = apt.get('verbose', '2') -%}
+{% set apt = pillar.get('apt', {}) -%}
+{% set unattended = apt.get('unattended', {}) -%}
+{% set enabled = unattended.get('enabled', '1') -%}
+{% set update_package_lists = unattended.get('update_package_lists', '1') -%}
+{% set download_upgradeable_packages = unattended.get('download_upgradeable_packages', '1') -%}
+{% set unattended_upgrade = unattended.get('unattended_upgrade', '1') -%}
+{% set auto_clean_interval = unattended.get('auto_clean_interval', '7') -%}
+{% set verbose = unattended.get('verbose', '2') -%}
 APT::Periodic::Enable "{{ enabled }}"; 
 APT::Periodic::Update-Package-Lists "{{ update_package_lists }}";
 APT::Periodic::Download-Upgradeable-Packages "{{ download_upgradeable_packages }}";

--- a/apt/templates/unattended_config.jinja
+++ b/apt/templates/unattended_config.jinja
@@ -1,15 +1,16 @@
-{% set apt = pillar.get('apt:unattended', {}) -%}
-{% set allowed_origins = apt.get('allowed_origins', ['${distro_id}:${distro_codename}-security']) -%}
-{% set package_blacklist = apt.get('package_blacklist', {}) -%}
-{% set auto_fix_interrupted_dpkg = apt.get('auto_fix_interrupted_dpkg', 'true') -%}
-{% set minimal_steps = apt.get('minimal_steps', 'false') -%}
-{% set install_on_shutdown = apt.get('install_on_shutdown', 'false') -%}
-{% set mail = apt.get('mail', 'root') -%}
-{% set mail_only_on_error = apt.get('mail_only_on_error', 'false') -%}
-{% set remove_unused_dependencies = apt.get('remove_unused_dependencies', 'true') -%}
-{% set automatic_reboot = apt.get('automatic_reboot', 'false') -%}
-{% set automatic_reboot_time = apt.get('automatic_reboot_time', 'now') -%}
-{% set dl_limit = apt.get('dl_limit', '0') -%}
+{% set apt = pillar.get('apt', {}) -%}
+{% set unattended = apt.get('unattended', {}) -%}
+{% set allowed_origins = unattended.get('allowed_origins', ['${distro_id}:${distro_codename}-security']) -%}
+{% set package_blacklist = unattended.get('package_blacklist', {}) -%}
+{% set auto_fix_interrupted_dpkg = unattended.get('auto_fix_interrupted_dpkg', 'true') -%}
+{% set minimal_steps = unattended.get('minimal_steps', 'false') -%}
+{% set install_on_shutdown = unattended.get('install_on_shutdown', 'false') -%}
+{% set mail = unattended.get('mail', 'root') -%}
+{% set mail_only_on_error = unattended.get('mail_only_on_error', 'false') -%}
+{% set remove_unused_dependencies = unattended.get('remove_unused_dependencies', 'true') -%}
+{% set automatic_reboot = unattended.get('automatic_reboot', 'false') -%}
+{% set automatic_reboot_time = unattended.get('automatic_reboot_time', 'now') -%}
+{% set dl_limit = unattended.get('dl_limit', '0') -%}
 Unattended-Upgrade::Allowed-Origins {
         {%- for pattern in allowed_origins %}
         "{{ pattern }}";


### PR DESCRIPTION
I previously called pillar.get('apt:unattended') which is not valid so it was not using custom values. I turned it into two separate pillar.get calls and verified it is pulling in custom values now.