### PR TITLE
Add protocol and port in pillar repository example for 3rd party repo

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -53,7 +53,7 @@ apt:
       url: http://linux.dropbox.com/debian
       arch: [i386, amd64]
       keyid: 1C61A2656FB57B7E4DE0F4C1FC918B335044912E
-      keyserver: pgp.mit.edu
+      keyserver: hkp://pgp.mit.edu:80
 
   preferences:
     00-rspamd:


### PR DESCRIPTION
When adding a third party repo, and thus a new key, gpg will fail with a "not able to connect" in some cases (most likely related to firewalling, but not investigated thoroughly): adding the specific protocol and port solves this issue.