### PR TITLE
Ensure sources.list exists but is empty (#19)

### DIFF
--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -10,10 +10,10 @@ debian-archive-keyring:
   pkg.installed
 
 /etc/apt/sources.list:
-  {% if remove_sources_list %}
-  file.absent
-  {% else %}
   file.managed:
+  {%- if remove_sources_list %}
+    - contents: ''
+  {%- else %}
     - mode: '0644'
     - user: root
     - group: root


### PR DESCRIPTION
Salt uses the aptsources system library to get a list of repositories on the host. Unfortunately if the /etc/apt/sources.list file is missing, aptsources.sourceslist.SourcesList() (which is called by salt) logs a
warning, which is then displayed to the user running salt.

To avoid this warning when using 'remove_sources_list: true' in pillar we can keep the /etc/apt/sources.list file, but just ensure it is empty. This achieves the same thing, but does not log the warning or display it to the user.