### PR TITLE
Minor fixes

### DIFF
--- a/apt/preferences.sls
+++ b/apt/preferences.sls
@@ -35,4 +35,9 @@
       - "{{ 'Package: ' ~ p_package }}"
       - "{{ 'Pin: ' ~ args.pin }}"
       - "{{ 'Pin-Priority: ' ~ args.priority }}"
+{% if 'explanation' in args %}
+{% for explanation in args.explanation %}
+      - "{{ 'Explanation: ' ~ explanation }}"
+{% endfor %}
+{% endif %}
 {% endfor %}

--- a/apt/preferences.sls
+++ b/apt/preferences.sls
@@ -30,7 +30,7 @@
   file.managed:
     - mode: '0644'
     - user: root
-    - group: root 
+    - group: root
     - contents:
       - "{{ 'Package: ' ~ p_package }}"
       - "{{ 'Pin: ' ~ args.pin }}"

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -51,4 +51,3 @@ debian-archive-keyring:
     - clean_file: true
   {%- endfor %}
 {% endfor %}
-

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -36,7 +36,7 @@ debian-archive-keyring:
   {%- for type in args.type|d(['binary']) %}
   {%- set r_type = 'deb-src' if type == 'source' else 'deb' %}
 
-{{ repo }}{{ type }}:
+{{ r_type }} {{ repo }}:
   pkgrepo.managed:
     - name: {{ r_type }} {{ r_arch }} {{ r_url }} {{ r_distro }} {{ r_comps }}
     - file: {{ sources_list_dir }}/{{ repo }}-{{ type }}.list
@@ -49,5 +49,6 @@ debian-archive-keyring:
     - keyserver: {{ r_keyserver }}
     {% endif %}
     - clean_file: true
+
   {%- endfor %}
 {% endfor %}

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -11,12 +11,12 @@ debian-archive-keyring:
 
 /etc/apt/sources.list:
   file.managed:
-  {%- if remove_sources_list %}
-    - contents: ''
-  {%- else %}
     - mode: '0644'
     - user: root
     - group: root
+  {% if remove_sources_list %}
+    - contents: ''
+    - contents_newline: False
   {% endif %}
 
 {{ sources_list_dir }}:

--- a/apt/templates/periodic_config.jinja
+++ b/apt/templates/periodic_config.jinja
@@ -6,7 +6,7 @@
 {% set unattended_upgrade = unattended.get('unattended_upgrade', '1') -%}
 {% set auto_clean_interval = unattended.get('auto_clean_interval', '7') -%}
 {% set verbose = unattended.get('verbose', '2') -%}
-APT::Periodic::Enable "{{ enabled }}"; 
+APT::Periodic::Enable "{{ enabled }}";
 APT::Periodic::Update-Package-Lists "{{ update_package_lists }}";
 APT::Periodic::Download-Upgradeable-Packages "{{ download_upgradeable_packages }}";
 APT::Periodic::Unattended-Upgrade "{{ unattended_upgrade }}";

--- a/apt/templates/unattended_config.jinja
+++ b/apt/templates/unattended_config.jinja
@@ -14,12 +14,12 @@
 Unattended-Upgrade::Allowed-Origins {
         {%- for pattern in allowed_origins %}
         "{{ pattern }}";
-        {%- endfor %} 
+        {%- endfor %}
 };
 Unattended-Upgrade::Package-Blacklist {
         {%- for package in package_blacklist %}
         "{{ package }}";
-        {%- endfor %} 
+        {%- endfor %}
 };
 Unattended-Upgrade::AutoFixInterruptedDpkg "{{ auto_fix_interrupted_dpkg }}";
 Unattended-Upgrade::MinimalSteps "{{ minimal_steps }}";

--- a/apt/unattended.sls
+++ b/apt/unattended.sls
@@ -9,7 +9,7 @@ apt_unattended_pkgs:
     - pkgs:
       {% for pkg in apt_map.pkgs %}
       - {{ pkg }}
-      {% endfor %}  
+      {% endfor %}
 
 {{ apt_map.confd_dir }}/{{ apt_map.unattended_config }}:
   file.managed:

--- a/pillar.example
+++ b/pillar.example
@@ -8,11 +8,11 @@ apt:
   unattended:
     allowed_origins:
       - origin1
-      - origin2  
-    package_blacklist:    
+      - origin2
+    package_blacklist:
       - package1
-      - package2  
-    auto_fix_interrupted_dpkg: true     
+      - package2
+    auto_fix_interrupted_dpkg: true
     minimal_steps: false
     install_on_shutdown: false
     mail: root


### PR DESCRIPTION
Random minor fixes in use at my workplace. Addresses the warnings in https://github.com/saltstack-formulas/apt-formula/issues/19 by leaving sources.list empty (which I would prefer to have happen anyway).

The only one you may not appreciate is the last commit (c9644b4) since it might break compatibility with existing states people have if they depend on the name in use, so feel free to cherry-pick as desired.