### PR TITLE
Permit an absent preferences pillar data key

### DIFF
--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -11,6 +11,7 @@
         'remove_sources_list': false,
         'clean_sources_list_d': false,
         'preferences_dir': '/etc/apt/preferences.d',
+        'preferences': {},
         'remove_preferences': false,
         'clean_preferences_d': false,
         'default_keyserver': 'pool.sks-keyservers.net',


### PR DESCRIPTION
The `preferences.sls` file has a line like:
`{% set preferences = apt.get('preferences', apt_map.preferences) %}`

In my pillar sls, I had an if condition such as:
```
{%- if oscodename == 'jessie' %}
  preferences:
    python-tornado:
      package: python-tornado
      pin: release a=jessie-backports
      priority: 950
      explanation:
        - Dependency for salt-minion.
{%- endif %}
```

When instances were upgraded to stretch, the preference key was no longer used which resulted in `Data failed to compile:` errors when trying to run highstate (since `apt.preferences` is still listed there).

In theory, I could just update `top.sls` to also have the same if condition around the `apt.preferences` reference, however that approach would lead to unnecessary code duplication - particularly as more if conditions need to be added for different os releases. Instead, I propose here we set a default `preferences` key with the value of an empty dict so the state can complete without error but still essentially do nothing.