### PR TITLE
Move keyring package name configuration to pillar

### DIFF
--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -16,6 +16,7 @@
         'clean_preferences_d': false,
         'default_keyserver': 'pool.sks-keyservers.net',
         'default_url': 'http://deb.debian.org/debian/',
+        'default_keyring_package': 'debian-archive-keyring',
         'repositories': {
           'sane_default': {
              'distro': distribution,
@@ -32,4 +33,3 @@
        },
     },
 }, merge=salt['pillar.get']('apt:lookup'), default='Debian') %}
-

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -5,8 +5,9 @@
 {% set sources_list_dir = apt.get('sources_list_dir', apt_map.sources_list_dir) %}
 {% set repositories = apt.get('repositories', apt_map.repositories) %}
 {% set default_url = apt.get('default_url', apt_map.default_url) %}
+{% set keyring_package = apt.get('keyring_package', apt_map.default_keyring_package) %}
 
-debian-archive-keyring:
+{{ keyring_package }}:
   pkg.installed
 
 /etc/apt/sources.list:

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,7 @@
 apt:
+  # Set the right keyring for the distro (ie ubuntu-keyring or ...)
+  keyring_package: debian-archive-keyring
+  
   remove_sources_list: true
   clean_sources_list_d: true
 
@@ -95,4 +98,3 @@ apt:
     03-all:
       pin: release unstable
       priority: 50
-


### PR DESCRIPTION
This request moves keyring package name configuration to pillar while continuing to use debian-archive-keyring as sane default.