### PR TITLE
fix iteritems python3

### DIFF
--- a/apt/preferences.sls
+++ b/apt/preferences.sls
@@ -23,7 +23,7 @@
     - group: root
     - clean: {{ clean_preferences_d }}
 
-{% for pref_file, args in preferences.iteritems() %}
+{% for pref_file, args in preferences.items() %}
 {%- set p_package = args.package if args.package is defined else '*' %}
 
 {{ preferences_dir }}/{{ pref_file }}:

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -29,7 +29,7 @@
 
 
 
-{% for repo, args in repositories.iteritems() %}
+{% for repo, args in repositories.items() %}
 
 {% set r_opts = '' %}
 {%- set r_arch = 'arch=' ~ args.arch|join(',') if args.arch is defined else '' %}


### PR DESCRIPTION
iteritems is deprecatedd with python3 should be items()