### PR TITLE
fix warning on preferences as not managed

### DIFF
--- a/apt/preferences.sls
+++ b/apt/preferences.sls
@@ -7,13 +7,15 @@
 {% set default_url = apt.get('default_url', apt_map.default_url) %}
 
 /etc/apt/preferences:
-  {% if remove_preferences %}
-  file.absent
-  {% else %}
   file.managed:
     - mode: '0644'
     - user: root
     - group: root
+  {% if remove_preferences %}
+    - contents: ''
+    - contents_newline: False
+  {% else %}
+    - replace: False
   {% endif %}
 
 {{ preferences_dir }}:

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -18,6 +18,8 @@
   {% if remove_sources_list %}
     - contents: ''
     - contents_newline: False
+  {% else %}
+    - replace: False
   {% endif %}
 
 {{ sources_list_dir }}:


### PR DESCRIPTION
[WARNING ] State for file: /etc/apt/preferences - Neither 'source' nor
'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet
'replace' was set to 'True'. As there is no source to replace the file
with, 'replace' has been set to 'False' to avoid reading the file
unnecessarily.