### PR TITLE
fix(apt-get-update refresh): add multiple repo, but only refresh once

### DIFF
--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -74,6 +74,16 @@
     - keyserver: {{ r_keyserver }}
     {% endif %}
     - clean_file: true
+    - refresh: False
+    - refresh_db: False
+    - onchanges_in:
+      - module: apt.refresh_db
 
   {%- endfor %}
 {% endfor %}
+
+{% if repositories %}
+apt.refresh_db:
+  module.run:
+    - name: pkg.refresh_db
+{% endif %}


### PR DESCRIPTION
Currently, adding multiple repository launches an apt-get update after each repository.

Those changes allows to add mulitple repositories at once, and only do the refresh once.