### PR TITLE
select repo key package based on grains['os']

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,13 @@
 apt:
   # Set the right keyring for the distro (ie ubuntu-keyring or ...)
+  {% if grains['os'] == 'Debian' %}
   keyring_package: debian-archive-keyring
+  {% elif grains['os'] == 'Ubuntu' %}
+  keyring_package: ubuntu-keyring
+  {% elif grains['os'] == 'Mint' %}
+  keyring_package: linuxmint-keyring
+  {% endif %}
+
   
   remove_sources_list: true
   clean_sources_list_d: true


### PR DESCRIPTION
Added if/else based on grains['os'] around common keyring packages to pillar.example.  Simple change, but makes the example more usable and should promote pulls with additional distribution details.

