### PR TITLE
also pass check when opt_data is a number

### DIFF
--- a/apt/templates/apt_conf.jinja
+++ b/apt/templates/apt_conf.jinja
@@ -11,7 +11,7 @@
 {%- endmacro -%}
 // This file is managed by salt
 {%- for opt, opt_data in data|dictsort -%}
-  {%- if opt_data is string %}
+  {%- if opt_data is string or opt_data is number %}
 {{ opt }} "{{ opt_data }}";
   {%- elif opt_data is mapping %}
 {{ opt }}


### PR DESCRIPTION
When adding a pillar like followed, the apt_conf will fail to add the option, as it only checks for strings, not for numbers. This behaviour is confusing in my opinion.
```
apt:
  apt_conf_d:
    99no-check-valid-until:
      'Acquire::Check-Valid-Until': 0
```