### PR TITLE
chore: use `semantic-release` cross-formula standard structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 stages:
   - test
   - commitlint


### PR DESCRIPTION
* Automated using `ssf-formula` (v0.1.0-rc.3)