### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -33,16 +33,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/repositories.pillar.sls test/salt/pillar/preferences.pillar.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@
 apt:
   # Set the right keyring for the distro (ie ubuntu-keyring or ...)
   keyring_package: debian-archive-keyring
-  
+
   remove_sources_list: true
   clean_sources_list_d: true
 

--- a/test/integration/preferences/inspec.yml
+++ b/test/integration/preferences/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: preferences
 title: apt formula
 maintainer: SaltStack Formulas

--- a/test/integration/repositories/inspec.yml
+++ b/test/integration/repositories/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: repositories
 title: apt formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/preferences.pillar.sls
+++ b/test/salt/pillar/preferences.pillar.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 apt:
   remove_preferences: true
   clean_preferences_d: true

--- a/test/salt/pillar/repositories.pillar.sls
+++ b/test/salt/pillar/repositories.pillar.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 apt:
   remove_sources_list: true
   clean_sources_list_d: true
@@ -16,4 +19,3 @@ apt:
       arch: [amd64]
       comps: []
       key_url: https://cli-assets.heroku.com/apt/release.key
-


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
apt-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  7:1       error    trailing spaces  (trailing-spaces)

test/salt/pillar/repositories.pillar.sls
  1:1       warning  missing document start "---"  (document-start)
  19:1      error    too many blank lines (1 > 0)  (empty-lines)

test/salt/pillar/preferences.pillar.sls
  1:1       warning  missing document start "---"  (document-start)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.