### PR TITLE
fix(repositories): update spotify repo key

### DIFF
--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -69,6 +69,8 @@
        the latter will be used. #}
     {% if args.key_url is defined %}
     - key_url: {{ args.key_url }}
+    {% elif args.key_text is defined %}
+    - key_text: {{ args.key_text }}
     {% elif args.keyid is defined %}
     - keyid: {{ args.keyid }}
     - keyserver: {{ r_keyserver }}

--- a/test/salt/pillar/repositories.pillar.sls
+++ b/test/salt/pillar/repositories.pillar.sls
@@ -8,7 +8,7 @@ apt:
       url: http://repository.spotify.com
       arch: [amd64]
       comps: [non-free]
-      keyid: 931FF8E79F0876134EDDBDCCA87FF9DF48BF1C90
+      keyid: 2EBF997C15BDA244B6EBF5D84773BD5E130D1D45
       keyserver: keyserver.ubuntu.com
     heroku:
       distro: ./


### PR DESCRIPTION
As mentioned here: https://github.com/saltstack-formulas/apt-formula/pull/49#issuecomment-519225361.