### PR TITLE
fix(2019.2 compliant): add name so no virtual_packages

### DIFF
--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -8,7 +8,8 @@
 {% set keyring_package = apt.get('keyring_package', apt_map.default_keyring_package) %}
 
 {{ keyring_package }}:
-  pkg.installed
+  pkg.installed:
+    - name: {{ keyring_package }}
 
 /etc/apt/sources.list:
   file.managed:

--- a/apt/transports/debtorrent.sls
+++ b/apt/transports/debtorrent.sls
@@ -1,2 +1,3 @@
 apt-transport-debtorrent:
-  pkg.installed
+  pkg.installed:
+    - name: apt-transport-debtorrent

--- a/apt/transports/https.sls
+++ b/apt/transports/https.sls
@@ -1,2 +1,3 @@
 apt-transport-https:
-  pkg.installed
+  pkg.installed:
+    - name: apt-transport-https


### PR DESCRIPTION
Saltstack fluorine (2019.2) fixes: VIRTUAL PACKAGE" SUPPORT DROPPED FOR APT

https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#virtual-package-support-dropped-for-apt

fixes: #51 