### PR TITLE
Add new unattended settings

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,15 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
 ---
+# For help on this file's format, see https://kitchen.ci/
 driver:
-  name: vagrant
+  name: docker
+  use_sudo: false
+  privileged: true
+  run_command: /lib/systemd/systemd
 
 platforms:
-  - name: debian-jessie64
-    driver_config:
-      box: ssplatt/salt-deb-8
+   ## SALT `2019.2`
+  - name: debian-10-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:debian-10
+  - name: debian-9-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:debian-9
+  - name: ubuntu-1804-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:ubuntu-18.04
 
 provisioner:
   name: salt_solo
-  salt_version: 2015.8.8
+  log_level: debug
+  salt_install: none
+  require_chef: false
   data_path: test/shared
   is_file_root: true
   pillars-from-files:
@@ -19,20 +34,14 @@ provisioner:
       base:
         '*':
           - apt
-  grains:
-    os_family: Debian
 
 suites:
-  - name: repositories
+  - name: default
     provisioner:
       state_top:
         base:
           '*':
             - apt.repositories
             - apt.update
-  - name: preferences
-    provisioner:
-      state_top:
-        base:
-          '*':
+            - apt.unattended
             - apt.preferences

--- a/apt/preferences.sls
+++ b/apt/preferences.sls
@@ -23,7 +23,7 @@
     - group: root
     - clean: {{ clean_preferences_d }}
 
-{% for pref_file, args in preferences.iteritems() %}
+{% for pref_file, args in preferences.items() %}
 {%- set p_package = args.package if args.package is defined else '*' %}
 
 {{ preferences_dir }}/{{ pref_file }}:

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -26,7 +26,7 @@ debian-archive-keyring:
     - group: root
     - clean: {{ clean_sources_list_d }}
 
-{% for repo, args in repositories.iteritems() %}
+{% for repo, args in repositories.items() %}
 {%- set r_arch = '[arch=' ~ args.arch|join(',') ~ ']' if args.arch is defined else '' %}
 {%- set r_url = args.url or default_url %}
 {%- set r_distro = args.distro or 'stable' %}

--- a/apt/templates/unattended_config.jinja
+++ b/apt/templates/unattended_config.jinja
@@ -1,3 +1,5 @@
+# This file is managed by salt. Manual changes risk being overwritten.
+
 {% set apt = pillar.get('apt', {}) -%}
 {% set unattended = apt.get('unattended', {}) -%}
 {% set allowed_origins = unattended.get('allowed_origins', ['${distro_id}:${distro_codename}-security']) -%}
@@ -6,12 +8,25 @@
 {% set auto_fix_interrupted_dpkg = unattended.get('auto_fix_interrupted_dpkg', 'true') -%}
 {% set minimal_steps = unattended.get('minimal_steps', 'false') -%}
 {% set install_on_shutdown = unattended.get('install_on_shutdown', 'false') -%}
-{% set mail = unattended.get('mail', 'root') -%}
+{% set mail = unattended.get('mail', '') -%}
+{% set sender = unattended.get('sender', 'root') -%}
 {% set mail_only_on_error = unattended.get('mail_only_on_error', 'false') -%}
-{% set remove_unused_dependencies = unattended.get('remove_unused_dependencies', 'true') -%}
+{% set mail_report = unattended.get('mail_report', '') -%}
+{% if mail_report not in ['always', 'only-on-error', 'on-change'] -%}
+{%   set mail_report = 'on-change' -%}
+{% endif -%}
+{% set remove_unused_dependencies = unattended.get('remove_unused_dependencies', 'false') -%}
+{% set remove_new_unused_dependencies = unattended.get('remove_new_unused_dependencies', 'true') -%}
 {% set automatic_reboot = unattended.get('automatic_reboot', 'false') -%}
 {% set automatic_reboot_time = unattended.get('automatic_reboot_time', 'now') -%}
 {% set dl_limit = unattended.get('dl_limit', '0') -%}
+{% set syslog_enable = unattended.get('syslog_enable', 'false') -%}
+{% set syslog_facility = unattended.get('syslog_facility', 'daemon') -%}
+{% set package_whitelist_strict = unattended.get('package_whitelist_strict', 'false') -%}
+{% set keep_debs_after_install = unattended.get('keep_debs_after_install', 'false') -%}
+{% set dpkg_options = unattended.get('dpkg_options', '') -%}
+{% set update_days = unattended.get('update_days', '') -%}
+
 Unattended-Upgrade::Allowed-Origins {
         {%- for pattern in allowed_origins %}
         "{{ pattern }}";
@@ -31,8 +46,21 @@ Unattended-Upgrade::AutoFixInterruptedDpkg "{{ auto_fix_interrupted_dpkg }}";
 Unattended-Upgrade::MinimalSteps "{{ minimal_steps }}";
 Unattended-Upgrade::InstallOnShutdown "{{ install_on_shutdown }}";
 Unattended-Upgrade::Mail "{{ mail }}";
+Unattended-Upgrade::Sender "{{ sender }}";
 Unattended-Upgrade::MailOnlyOnError "{{ mail_only_on_error }}";
+Unattended-Upgrade::MailReport "{{ mail_report }}";
 Unattended-Upgrade::Remove-Unused-Dependencies "{{ remove_unused_dependencies }}";
+Unattended-Upgrade::Remove-New-Unused-Dependencies "{{ remove_new_unused_dependencies }}";
 Unattended-Upgrade::Automatic-Reboot "{{ automatic_reboot }}";
 Unattended-Upgrade::Automatic-Reboot-Time "{{ automatic_reboot_time }}";
+Unattended-Upgrade::SyslogEnable "{{ syslog_enable }}";
+Unattended-Upgrade::SyslogFacility "{{ syslog_facility }}";
+Unattended-Upgrade::Keep-Debs-After-Install "{{ keep_debs_after_install }}";
+Unattended-Upgrade::Package-Whitelist-Strict "{{ package_whitelist_strict }}";
 Acquire::http::Dl-Limit "{{ dl_limit }}";
+{% if dpkg_options -%}
+Dpkg::Options {"{{ dpkg_options }}"};
+{% endif -%}
+{% if update_days and update_days | is_list -%}
+Unattended-Upgrade::Update-Days {"{{ update_days | join('";"') }}"}
+{% endif -%}

--- a/pillar.example
+++ b/pillar.example
@@ -20,7 +20,10 @@ apt:
     minimal_steps: false
     install_on_shutdown: false
     mail: root
-    mail_only_on_error: false
+    sender: root
+    # Prefer using `mail_report: 'only-on-error'` over old syntax `mail_only_on_error: false`
+    # allowed values: 'always', 'only-on-error', 'on-change'
+    mail_report: 'only-on-error'
     remove_unused_dependencies: true
     automatic_reboot: false
     dl_limit: 0
@@ -30,6 +33,12 @@ apt:
     unattended_upgrade: 1
     auto_clean_interval: 7
     verbose: 2
+    syslog_enable: true
+    syslog_facility: 'auth'
+    dpkg_options: '--force-confold'
+    update_days: ['Mon', 'Fri']
+    package_whitelist_strict: false
+    keep_debs_after_install: false
 
   listchanges:
     profiles:
@@ -48,28 +57,25 @@ apt:
       distro: stable/updates
       url: http://security.debian.org
       comps: [main, contrib, non-free]
-      arch: [amd64, i386]
+      arch: [amd64]
       type: [binary, source]
+      key_url: https://ftp-master.debian.org/keys/archive-key-10-security.asc
     updates:
       distro: stable-updates
       url: http://httpredir.debian.org/debian/
       comps: [main, contrib, non-free]
+      key_url: https://ftp-master.debian.org/keys/archive-key-10.asc
     raspbian:
-      distro: wheezy
+      distro: stable
       url: http://archive.raspbian.org/raspbian
       type: [source]
       key_url: https://archive.raspbian.org/raspbian.public.key
-    debian-jessie:
-      distro: jessie
+    debian-buster:
+      distro: buster
       url: http://httpredir.debian.org/debian
       type: [source]
       comps: [main, contrib, non-free]
-    dropbox:
-      distro: jessie
-      url: http://linux.dropbox.com/debian
-      arch: [i386, amd64]
-      keyid: 1C61A2656FB57B7E4DE0F4C1FC918B335044912E
-      keyserver: hkp://pgp.mit.edu:80
+      key_url: https://ftp-master.debian.org/keys/archive-key-10.asc
 
   preferences:
     00-rspamd:


### PR DESCRIPTION
Some of the unattended settings updated from upstream are not reflected in the template. This PR updates settings with the ones from https://github.com/mvo5/unattended-upgrades.

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing

Updated:
* jinja templates with new settings
* `pillar.example` with new examples
* defaults match upstream
* .kitchen.yml tests with updated versions

### Pillar / config required to test the proposed changes

Can be tested with updated pillar.example

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->
```
                 ID: /etc/apt/preferences.d/03-all
           Function: file.managed
             Result: True
            Comment: File /etc/apt/preferences.d/03-all updated
            Started: 03:12:58.002144
           Duration: 1.924 ms
            Changes:   
              ----------
              diff:
                  New file
              mode:
                  0644
       
       Summary for local
       -------------
       Succeeded: 18 (changed=15)
       Failed:     0
       -------------
       Total states run:     18
       Total run time:   17.125 s
       Downloading files from <default-ubuntu-1804-2019-2-py3>
       Finished converging <default-ubuntu-1804-2019-2-py3> (0m31.43s).
-----> Setting up <default-ubuntu-1804-2019-2-py3>...
       Finished setting up <default-ubuntu-1804-2019-2-py3> (0m0.00s).
-----> Verifying <default-ubuntu-1804-2019-2-py3>...
       Preparing files for transfer
       Transferring files to <default-ubuntu-1804-2019-2-py3>
       Finished verifying <default-ubuntu-1804-2019-2-py3> (0m0.00s).
-----> Destroying <default-ubuntu-1804-2019-2-py3>...
       UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
       root                20202               20182               0                   22:12               ?                   00:00:00            /lib/systemd/systemd
       root                20252               20202               0                   22:12               ?                   00:00:00            /lib/systemd/systemd-journald
       root                20258               20202               0                   22:12               ?                   00:00:00            /lib/systemd/systemd-udevd
       102                 20318               20202               0                   22:12               ?                   00:00:00            /lib/systemd/systemd-resolved
       root                20338               20202               0                   22:12               ?                   00:00:00            /lib/systemd/systemd-logind
       root                20339               20202               0                   22:12               ?                   00:00:00            /usr/bin/python3 /usr/bin/salt-minion
       root                20340               20202               0                   22:12               ?                   00:00:00            /usr/sbin/cron -f
       root                20341               20202               0                   22:12               ?                   00:00:00            /usr/bin/python3 /usr/bin/networkd-dispatcher --run-startup-triggers
       103                 20342               20202               0                   22:12               ?                   00:00:00            /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
       root                20345               20202               0                   22:12               tty1                00:00:00            /sbin/agetty -o -p -- \u --noclear tty1 linux
       root                20346               20202               0                   22:12               ?                   00:00:00            /usr/sbin/sshd -D
       root                20348               20202               0                   22:12               ?                   00:00:00            /usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown --wait-for-signal
       root                20564               20339               6                   22:12               ?                   00:00:02            /usr/bin/python3 /usr/bin/salt-minion
       root                20571               20564               0                   22:12               ?                   00:00:00            /usr/bin/python3 /usr/bin/salt-minion
       fzipi               20580               20202               0                   22:12               ?                   00:00:00            /lib/systemd/systemd --user
       fzipi               20581               20580               0                   22:12               ?                   00:00:00            (sd-pam)
       root                20602               20346               0                   22:12               ?                   00:00:00            sshd: kitchen [priv]
       fzipi               20617               20602               0                   22:12               ?                   00:00:00            sshd: kitchen@notty
       544bcd501fcb3d10d420b24b74bc137d04f190e79e6a3b6cc8744f993fcfe96e
       544bcd501fcb3d10d420b24b74bc137d04f190e79e6a3b6cc8744f993fcfe96e
       Finished destroying <default-ubuntu-1804-2019-2-py3> (0m1.18s).
       Finished testing <default-ubuntu-1804-2019-2-py3> (1m16.29s).
-----> Test Kitchen is finished. (1m16.38s)
```

There are no InSpec tests in this formula yet. I guess still needs to be migrated (could do this in a new PR).

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


