### PR TITLE
fix(map.jinja): fix debian security repo url

### DIFF
--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -31,8 +31,8 @@
                 'opts': 'signed-by=/usr/share/keyrings/debian-archive-keyring.gpg'
             },
             'security-stable': {
-                'distro': distribution ~ '/updates',
-                'url': 'http://security.debian.org/',
+                'distro': distribution ~ '-security',
+                'url': 'http://security.debian.org/debian-security',
                 'arch': arch,
                 'comps': debian_comp,
                 'opts': 'signed-by=/usr/share/keyrings/debian-archive-keyring.gpg'


### PR DESCRIPTION
URL scheme for the Debian security suite changed with Debian Bullseye, see 5.1.3. in https://www.debian.org/releases/bullseye/amd64/release-notes.en.txt

Debian releases older than Bullseye are EOL and not supported by Salt, so no need to maintain backwards compatibility.
